### PR TITLE
feat: Add Device auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ide
+.vscode

--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@ The building blocks of our wildfire detection & monitoring API.
 
 ## Table of Contents
 
-- [Getting Started](#getting-started)
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
-- [Usage](#usage)
-- [Documentation](#documentation)
-- [Contributing](#contributing)
-- [License](#license)
+- [Pyronear API](#pyronear-api)
+  - [Table of Contents](#table-of-contents)
+  - [Getting started](#getting-started)
+    - [Prerequisites](#prerequisites)
+    - [Installation](#installation)
+  - [Usage](#usage)
+  - [Run tests on Docker](#run-tests-on-docker)
+  - [Documentation](#documentation)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 
 
@@ -46,6 +49,13 @@ PORT=8002 docker-compose up -d --build
 
 Once completed, you will notice that you have a docker container running on the port you selected, which can process requests just like any django server.
 
+
+## Run tests on Docker
+Once the project has been built with docker using the previous command above. One can launch the unit tests using the following instruction:
+
+```bash
+PORT=8002 docker-compose exec web pyttest .
+```
 
 
 ## Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@ fastapi==0.61.1
 uvicorn>=0.11.1
 databases[postgresql]>=0.2.6
 SQLAlchemy>=1.3.12
+python-multipart>=0.0.5
+passlib[bcrypt]>=1.7.2
+python-jose[cryptography]
 
 # dev
 pytest>=5.3.2

--- a/src/app/api/routes/authorization.py
+++ b/src/app/api/routes/authorization.py
@@ -26,5 +26,5 @@ async def login_device(form_data: OAuth2PasswordRequestForm = Depends()):
     if not device:
         raise HTTPException(status_code=400, detail="Incorrect username or password")
 
-    access_token = create_unlimited_access_token(data=device.id)
+    access_token = create_unlimited_access_token(data={"sub": device.id, "scopes": form_data.scopes} )
     return {"access_token": access_token, "token_type": "bearer"}

--- a/src/app/api/routes/authorization.py
+++ b/src/app/api/routes/authorization.py
@@ -1,0 +1,30 @@
+from typing import List
+from fastapi import APIRouter, Path, Depends, HTTPException, status
+from app.api import routing, crud
+from app.db import devices
+from app.security import get_password_hash, verify_password, create_unlimited_access_token
+from app.api.schemas import Device, Token
+from fastapi.security import OAuth2PasswordRequestForm
+
+router = APIRouter()
+
+
+async def authenticate_device(db, username: str, password: str):
+    device = await crud.get(int(username), devices)
+    if not device:
+        return False
+    device = Device(**device)
+    if not verify_password(password, device.hashed_password):
+        return False
+    return device
+
+
+@router.post("/token", response_model=Token)
+async def login_device(form_data: OAuth2PasswordRequestForm = Depends()):
+    device = await authenticate_device(devices, form_data.username, form_data.password)
+
+    if not device:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+
+    access_token = create_unlimited_access_token(data=device.id)
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/src/app/api/routes/authorization.py
+++ b/src/app/api/routes/authorization.py
@@ -26,5 +26,5 @@ async def login_device(form_data: OAuth2PasswordRequestForm = Depends()):
     if not device:
         raise HTTPException(status_code=400, detail="Incorrect username or password")
 
-    access_token = create_unlimited_access_token(data={"sub": device.id, "scopes": form_data.scopes} )
+    access_token = create_unlimited_access_token(data={"sub": device.id, "scopes": form_data.scopes})
     return {"access_token": access_token, "token_type": "bearer"}

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -1,8 +1,10 @@
 from typing import List
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, Path, Depends, HTTPException
 from app.api import routing
 from app.db import devices
-from app.api.schemas import DeviceOut, DeviceIn
+from app.api.schemas import Device, DeviceOut, DeviceIn, DeviceDBIn, HeartbeatOut, HeartbeatIn
+from app.security import get_password_hash
+from app.deps import get_current_active_device
 
 
 router = APIRouter()
@@ -10,7 +12,8 @@ router = APIRouter()
 
 @router.post("/", response_model=DeviceOut, status_code=201)
 async def create_device(payload: DeviceIn):
-    return await routing.create_entry(devices, payload)
+    device = DeviceDBIn(**payload.dict(), hashed_password=get_password_hash(payload.password))
+    return await routing.create_entry(devices, device)
 
 
 @router.get("/{id}/", response_model=DeviceOut)
@@ -26,6 +29,12 @@ async def fetch_devices():
 @router.put("/{id}/", response_model=DeviceOut)
 async def update_device(payload: DeviceIn, id: int = Path(..., gt=0)):
     return await routing.update_entry(devices, payload, id)
+
+
+@router.put("/{id}/heartbeat/")  # , response_model=HeartbeatOut)
+async def heartbeat(id: int = Path(..., gt=0), current_device: Device = Depends(get_current_active_device)):
+    # , payload=HeartbeatIn, id: int = Path(..., gt=0)): #payload: DeviceIn, id: int = Path(..., gt=0)):
+    return current_device  # await routing.update_entry(devices, payload, id)
 
 
 @router.delete("/{id}/", response_model=DeviceOut)

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -5,7 +5,7 @@ from app.db import devices
 from app.api.schemas import Device, DeviceOut, DeviceIn, DeviceDBIn, HeartbeatOut, HeartbeatIn
 from app.security import get_password_hash
 from app.deps import get_current_active_device
-
+from datetime import datetime
 
 router = APIRouter()
 
@@ -31,11 +31,11 @@ async def update_device(payload: DeviceIn, id: int = Path(..., gt=0)):
     return await routing.update_entry(devices, payload, id)
 
 
-@router.put("/{id}/heartbeat/")  # , response_model=HeartbeatOut)
-async def heartbeat(id: int = Path(..., gt=0), current_device: Device = Depends(get_current_active_device)):
-    # , payload=HeartbeatIn, id: int = Path(..., gt=0)): #payload: DeviceIn, id: int = Path(..., gt=0)):
-    return current_device  # await routing.update_entry(devices, payload, id)
-
+@router.put("/{id}/heartbeat/", response_model=HeartbeatOut)
+async def heartbeat(current_device: Device = Depends(get_current_active_device), id: int = Path(..., gt=0)):
+    current_device.last_ping = datetime.utcnow()
+    return await routing.update_entry(devices, Device(**current_device), id)
+    
 
 @router.delete("/{id}/", response_model=DeviceOut)
 async def delete_device(id: int = Path(..., gt=0)):

--- a/src/app/api/routes/devices.py
+++ b/src/app/api/routes/devices.py
@@ -2,7 +2,7 @@ from typing import List
 from fastapi import APIRouter, Path, Depends, HTTPException
 from app.api import routing
 from app.db import devices
-from app.api.schemas import Device, DeviceOut, DeviceIn, DeviceDBIn, HeartbeatOut, HeartbeatIn
+from app.api.schemas import BaseDevice, Device, DeviceOut, DeviceIn, DeviceDBIn, HeartbeatOut, HeartbeatIn
 from app.security import get_password_hash
 from app.deps import get_current_active_device
 from datetime import datetime
@@ -31,11 +31,12 @@ async def update_device(payload: DeviceIn, id: int = Path(..., gt=0)):
     return await routing.update_entry(devices, payload, id)
 
 
-@router.put("/{id}/heartbeat/", response_model=HeartbeatOut)
-async def heartbeat(current_device: Device = Depends(get_current_active_device), id: int = Path(..., gt=0)):
-    current_device.last_ping = datetime.utcnow()
-    return await routing.update_entry(devices, Device(**current_device), id)
-    
+@router.post("/heartbeat", response_model=HeartbeatOut)
+async def heartbeat(current_device: Device = Depends(get_current_active_device)):
+    payload = dict(**current_device)
+    payload["last_ping"] = datetime.utcnow()
+    return await routing.update_entry(devices, BaseDevice(**payload), current_device["id"])
+
 
 @router.delete("/{id}/", response_model=DeviceOut)
 async def delete_device(id: int = Path(..., gt=0)):

--- a/src/app/api/routing.py
+++ b/src/app/api/routing.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 
 async def create_entry(table: Table, payload: BaseModel):
     entry_id = await crud.post(payload, table)
-
     return {**payload.dict(), "id": entry_id}
 
 

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -103,9 +103,9 @@ class HeartbeatIn(BaseModel):
 
 
 class HeartbeatOut(BaseModel):
-    ping: datetime = None
+    last_ping: datetime = None
 
-    @validator('ping', pre=True, always=True)
+    @validator('last_ping', pre=True, always=True)
     def default_ts_created(cls, v):
         return v or datetime.utcnow()
 

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -1,7 +1,17 @@
 from datetime import datetime
+from typing import Optional
 from pydantic import BaseModel, Field, validator
 
 from app.db import SiteType, EventType, MediaType, AlertType
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class TokenPayload(BaseModel):
+    sub: Optional[int] = None
 
 
 class UserIn(BaseModel):
@@ -50,7 +60,7 @@ class EventOut(EventIn):
         return v or datetime.utcnow()
 
 
-class DeviceIn(BaseModel):
+class BaseDevice(BaseModel):
     name: str = Field(..., min_length=3, max_length=50)
     owner_id: int = Field(..., gt=0)
     specs: str = Field(..., min_length=3, max_length=100)
@@ -62,11 +72,40 @@ class DeviceIn(BaseModel):
     last_ping: datetime = None
 
 
-class DeviceOut(DeviceIn):
+class DeviceIn(BaseDevice):
+    password: str = Field(..., min_length=8, max_length=50)
+
+
+class DeviceDBIn(BaseDevice):
+    hashed_password: str = Field(...)
+
+
+class DeviceOut(BaseDevice):
     id: int = Field(..., gt=0)
     created_at: datetime = None
 
     @validator('created_at', pre=True, always=True)
+    def default_ts_created(cls, v):
+        return v or datetime.utcnow()
+
+
+class Device(DeviceOut):
+    hashed_password: str = Field(...)
+
+
+class HeartbeatIn(BaseModel):
+    id: int = Field(..., gt=0)
+    ping: datetime = None
+
+    @validator('ping', pre=True, always=True)
+    def default_ts_created(cls, v):
+        return v or datetime.utcnow()
+
+
+class HeartbeatOut(BaseModel):
+    ping: datetime = None
+
+    @validator('ping', pre=True, always=True)
     def default_ts_created(cls, v):
         return v or datetime.utcnow()
 

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List
 from pydantic import BaseModel, Field, validator
 
 from app.db import SiteType, EventType, MediaType, AlertType
@@ -12,6 +12,7 @@ class Token(BaseModel):
 
 class TokenPayload(BaseModel):
     sub: Optional[int] = None
+    scopes: List[str] = []
 
 
 class UserIn(BaseModel):
@@ -104,10 +105,6 @@ class HeartbeatIn(BaseModel):
 
 class HeartbeatOut(BaseModel):
     last_ping: datetime = None
-
-    @validator('last_ping', pre=True, always=True)
-    def default_ts_created(cls, v):
-        return v or datetime.utcnow()
 
 
 class MediaIn(BaseModel):

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -7,3 +7,6 @@ VERSION: str = "0.1.0a0"
 DEBUG: bool = os.environ.get('DEBUG', '') != 'False'
 DATABASE_URL: str = os.getenv("DATABASE_URL")
 LOGO_URL: str = "https://github.com/pyronear/PyroNear/raw/master/docs/source/_static/img/pyronear-logo-dark.png"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+ACCESS_TOKEN_UNLIMITED_MINUTES = 60 * 24 * 365 * 10
+SECRET_KEY = "09d25e094faa6ca2556c818166b7a9563b93f7099f6f0f4caa6cf63b88e8d3e7"

--- a/src/app/db.py
+++ b/src/app/db.py
@@ -72,6 +72,7 @@ devices = Table(
     Column("last_pitch", Float(1, asdecimal=True), default=None, nullable=True),
     Column("last_ping", DateTime, default=None, nullable=True),
     Column("created_at", DateTime, default=func.now()),
+    Column("hashed_password", String(100))
 )
 
 

--- a/src/app/deps.py
+++ b/src/app/deps.py
@@ -1,0 +1,38 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt, JWTError
+
+from app import config, security
+from app.db import devices
+from app.api import crud
+from app.api.schemas import Device, TokenPayload
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="authorization/token")
+
+
+async def get_current_device(token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, config.SECRET_KEY, algorithms=[security.ALGORITHM])
+        sub: int = payload.get("sub")
+        if sub is None:
+            raise credentials_exception
+        token_data = TokenPayload(**payload)
+    except JWTError:
+        raise credentials_exception
+    device = await crud.get(token_data.sub, devices)
+    if device is None:
+        raise credentials_exception
+    return device
+
+
+async def get_current_active_device(current_device: Device = Depends(get_current_device)) -> Device:
+    # If one include the notion of active/disabled, the following code may be useful.
+    # if current_device.disabled:
+    #     raise HTTPException(status_code=400, detail="Inactive device")
+
+    return current_device

--- a/src/app/deps.py
+++ b/src/app/deps.py
@@ -1,38 +1,55 @@
-from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi import Depends, HTTPException, status, Security
+from fastapi.security import OAuth2PasswordBearer, SecurityScopes
 from jose import jwt, JWTError
 
 from app import config, security
 from app.db import devices
 from app.api import crud
 from app.api.schemas import Device, TokenPayload
+from pydantic import ValidationError
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="authorization/token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="authorization/token",
+    scopes={"heartbeat": "Send heartbeat signal to the API for only one device"},
+)
 
 
-async def get_current_device(token: str = Depends(oauth2_scheme)):
+async def get_current_device(
+    security_scopes: SecurityScopes, token: str = Depends(oauth2_scheme)):
+    if security_scopes.scopes:
+        authenticate_value = f'Bearer scope="{security_scopes.scope_str}"'
+    else:
+        authenticate_value = f"Bearer"
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
-        headers={"WWW-Authenticate": "Bearer"},
+        headers={"WWW-Authenticate": authenticate_value},
     )
-    try:
+    try:        
         payload = jwt.decode(token, config.SECRET_KEY, algorithms=[security.ALGORITHM])
         sub: int = payload.get("sub")
         if sub is None:
             raise credentials_exception
+        token_scopes = payload.get("scopes", [])
+        
         token_data = TokenPayload(**payload)
-    except JWTError:
+    except (JWTError, ValidationError):
         raise credentials_exception
     device = await crud.get(token_data.sub, devices)
     if device is None:
         raise credentials_exception
+
+    for scope in security_scopes.scopes:
+        if scope not in token_data.scopes:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Not enough permissions",
+                headers={"WWW-Authenticate": authenticate_value},
+            )
     return device
 
 
-async def get_current_active_device(current_device: Device = Depends(get_current_device)) -> Device:
+async def get_current_active_device(current_device: Device = Security(get_current_device, scopes=["heartbeat"])) -> Device:
     # If one include the notion of active/disabled, the following code may be useful.
     # if current_device.disabled:
     #     raise HTTPException(status_code=400, detail="Inactive device")
-
     return current_device

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 
 from app import config as cfg
-from app.api.routes import ping, users, sites, events, devices, media, installations, alerts
+from app.api.routes import ping, users, sites, events, devices, media, installations, alerts, authorization
 from app.db import engine, metadata, database
 
 metadata.create_all(engine)
@@ -31,6 +31,7 @@ app.include_router(devices.router, prefix="/devices", tags=["devices"])
 app.include_router(media.router, prefix="/media", tags=["media"])
 app.include_router(installations.router, prefix="/installations", tags=["installations"])
 app.include_router(alerts.router, prefix="/alerts", tags=["alerts"])
+app.include_router(authorization.router, prefix="/authorization", tags=["authorization"])
 
 
 # Middleware

--- a/src/app/security.py
+++ b/src/app/security.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timedelta
+from typing import Any, Union
+
+from jose import jwt
+from passlib.context import CryptContext
+
+from app import config
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+ALGORITHM = "HS256"
+
+
+def create_unlimited_access_token(data: Union[str, Any]) -> str:
+    return create_access_token(data, timedelta(minutes=config.ACCESS_TOKEN_UNLIMITED_MINUTES))
+
+
+def create_access_token(
+    subject: Union[str, Any], expires_delta: timedelta = None
+) -> str:
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(
+            minutes=config.ACCESS_TOKEN_EXPIRE_MINUTES
+        )
+    to_encode = {"exp": expire, "sub": str(subject)}
+    encoded_jwt = jwt.encode(to_encode, config.SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)

--- a/src/app/security.py
+++ b/src/app/security.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Union
+from typing import Any, Union, Dict
 
 from jose import jwt
 from passlib.context import CryptContext
@@ -12,12 +12,12 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 ALGORITHM = "HS256"
 
 
-def create_unlimited_access_token(data: Union[str, Any]) -> str:
+def create_unlimited_access_token(data: Dict) -> str:
     return create_access_token(data, timedelta(minutes=config.ACCESS_TOKEN_UNLIMITED_MINUTES))
 
 
 def create_access_token(
-    subject: Union[str, Any], expires_delta: timedelta = None
+    data: Dict, expires_delta: timedelta = None
 ) -> str:
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
@@ -25,7 +25,8 @@ def create_access_token(
         expire = datetime.utcnow() + timedelta(
             minutes=config.ACCESS_TOKEN_EXPIRE_MINUTES
         )
-    to_encode = {"exp": expire, "sub": str(subject)}
+    data["sub"] = str(data["sub"])
+    to_encode = {**data, "exp": expire}
     encoded_jwt = jwt.encode(to_encode, config.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 


### PR DESCRIPTION
### Description
The pull request adds a device authentification along with scopes. A device identifies itself directly instead of 

It is heavily based on FastAPI tutorial and FastAPI fullstack.

* Add a password field to the device creation
* Add Authorization route
* Add a security file
* Add a heartbeat mechanism to update the last_ping field of a device

### Description
This PR shall be amended when the user-auth PR is merged as there are multiple redundancies.
In addition, one should probably design a mechanism where a device has a user_id where this user_id type is "device", allowing it only to access devices routes.