### PR TITLE
chore: Updated CI triggers and refactored Dockerfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: fastapi-project
 
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   install-deps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN set -eux \
     && rm -rf /root/.cache/pip
 
 # copy project
-COPY . /usr/src/app/
+COPY src/ /usr/src/app/


### PR DESCRIPTION
This PR limits CI triggers to commit and PR on `master` branch. Additionally, fixes the Dockerfile to work as a standalone without docker-compose.