### PR TITLE
feat: Added a password update route

### DIFF
--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -16,8 +16,8 @@ async def get_my_user(me: UserRead = Security(get_current_user, scopes=["me"])):
     return me
 
 
-@router.put("/update-me", response_model=UserRead)
-async def update_me(payload: UserInfo, me: UserRead = Security(get_current_user, scopes=["me"])):
+@router.put("/update-info", response_model=UserRead)
+async def update_my_info(payload: UserInfo, me: UserRead = Security(get_current_user, scopes=["me"])):
     return await routing.update_entry(users, payload, me.id)
 
 

--- a/src/app/api/routes/users.py
+++ b/src/app/api/routes/users.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Path, Security, HTTPException
 
 from app.api import routing, security
 from app.db import users
-from app.api.schemas import UserInfo, UserRead, UserAuth, UserCreation
+from app.api.schemas import UserInfo, UserCred, UserRead, UserAuth, UserCreation
 from app.api.deps import get_current_user
 
 
@@ -19,6 +19,11 @@ async def get_my_user(me: UserRead = Security(get_current_user, scopes=["me"])):
 @router.put("/update-info", response_model=UserRead)
 async def update_my_info(payload: UserInfo, me: UserRead = Security(get_current_user, scopes=["me"])):
     return await routing.update_entry(users, payload, me.id)
+
+
+@router.put("/update-pwd", response_model=UserInfo)
+async def update_my_password(payload: UserCred, me: UserRead = Security(get_current_user, scopes=["me"])):
+    return await routing.update_user_pwd(users, payload, me.id)
 
 
 @router.post("/", response_model=UserRead, status_code=201)
@@ -43,6 +48,15 @@ async def update_user(
     _=Security(get_current_user, scopes=["admin"])
 ):
     return await routing.update_entry(users, payload, user_id)
+
+
+@router.put("/{user_id}/pwd", response_model=UserInfo)
+async def reset_password(
+    payload: UserCred,
+    user_id: int = Path(..., gt=0),
+    _=Security(get_current_user, scopes=["admin"])
+):
+    return await routing.update_user_pwd(users, payload, user_id)
 
 
 @router.delete("/{user_id}/", response_model=UserRead)

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -10,6 +10,15 @@ class UserInfo(BaseModel):
     username: str = Field(..., min_length=3, max_length=50)
 
 
+# Sensitive information about the user
+class UserCred(BaseModel):
+    password: str
+
+
+class UserCredHash(BaseModel):
+    hashed_password: str
+
+
 # Visible info
 class UserRead(UserInfo):
     id: int = Field(..., gt=0)

--- a/src/app/api/schemas.py
+++ b/src/app/api/schemas.py
@@ -5,6 +5,16 @@ from pydantic import BaseModel, Field, validator
 from app.db import SiteType, EventType, MediaType, AlertType
 
 
+# Template class
+class _CreatedAt(BaseModel):
+    created_at: datetime = None
+
+    @staticmethod
+    @validator('created_at', pre=True, always=True)
+    def default_ts_created(v):
+        return v or datetime.utcnow()
+
+
 # Abstract information about a user
 class UserInfo(BaseModel):
     username: str = Field(..., min_length=3, max_length=50)
@@ -20,25 +30,17 @@ class UserCredHash(BaseModel):
 
 
 # Visible info
-class UserRead(UserInfo):
+class UserRead(UserInfo, _CreatedAt):
     id: int = Field(..., gt=0)
-    created_at: datetime = None
-
-    @staticmethod
-    @validator('created_at', pre=True, always=True)
-    def default_ts_created(v):
-        return v or datetime.utcnow()
 
 
 # Authentication request
-class UserAuth(UserInfo):
-    password: str
+class UserAuth(UserInfo, UserCred):
     scopes: Optional[str] = "me"
 
 
 # Creation payload
-class UserCreation(UserInfo):
-    hashed_password: str
+class UserCreation(UserInfo, UserCredHash):
     scopes: str
 
 
@@ -59,14 +61,8 @@ class SiteIn(BaseModel):
     type: SiteType = SiteType.tower
 
 
-class SiteOut(SiteIn):
+class SiteOut(SiteIn, _CreatedAt):
     id: int = Field(..., gt=0)
-    created_at: datetime = None
-
-    @staticmethod
-    @validator('created_at', pre=True, always=True)
-    def default_ts_created(v):
-        return v or datetime.utcnow()
 
 
 class EventIn(BaseModel):
@@ -77,14 +73,8 @@ class EventIn(BaseModel):
     start_ts: datetime = None
 
 
-class EventOut(EventIn):
+class EventOut(EventIn, _CreatedAt):
     id: int = Field(..., gt=0)
-    created_at: datetime = None
-
-    @staticmethod
-    @validator('created_at', pre=True, always=True)
-    def default_ts_created(v):
-        return v or datetime.utcnow()
 
 
 class DeviceIn(BaseModel):
@@ -99,14 +89,8 @@ class DeviceIn(BaseModel):
     last_ping: datetime = None
 
 
-class DeviceOut(DeviceIn):
+class DeviceOut(DeviceIn, _CreatedAt):
     id: int = Field(..., gt=0)
-    created_at: datetime = None
-
-    @staticmethod
-    @validator('created_at', pre=True, always=True)
-    def default_ts_created(v):
-        return v or datetime.utcnow()
 
 
 class MediaIn(BaseModel):
@@ -114,14 +98,8 @@ class MediaIn(BaseModel):
     type: MediaType = MediaType.image
 
 
-class MediaOut(MediaIn):
+class MediaOut(MediaIn, _CreatedAt):
     id: int = Field(..., gt=0)
-    created_at: datetime = None
-
-    @staticmethod
-    @validator('created_at', pre=True, always=True)
-    def default_ts_created(v):
-        return v or datetime.utcnow()
 
 
 class InstallationIn(BaseModel):
@@ -136,14 +114,8 @@ class InstallationIn(BaseModel):
     end_ts: datetime = None
 
 
-class InstallationOut(InstallationIn):
+class InstallationOut(InstallationIn, _CreatedAt):
     id: int = Field(..., gt=0)
-    created_at: datetime = None
-
-    @staticmethod
-    @validator('created_at', pre=True, always=True)
-    def default_ts_created(v):
-        return v or datetime.utcnow()
 
 
 class AlertIn(BaseModel):
@@ -156,11 +128,5 @@ class AlertIn(BaseModel):
     is_acknowledged: bool = False
 
 
-class AlertOut(AlertIn):
+class AlertOut(AlertIn, _CreatedAt):
     id: int = Field(..., gt=0)
-    created_at: datetime = None
-
-    @staticmethod
-    @validator('created_at', pre=True, always=True)
-    def default_ts_created(v):
-        return v or datetime.utcnow()

--- a/src/tests/test_users.py
+++ b/src/tests/test_users.py
@@ -103,7 +103,7 @@ def test_fetch_users(test_app, monkeypatch):
     assert [{k: v for k, v in r.items() if k != 'created_at'} for r in response.json()] == test_data
 
 
-def test_update_user(test_app, monkeypatch):
+def test_update_user_info(test_app, monkeypatch):
     async def mock_get(entry_id, table):
         return True
 
@@ -121,7 +121,7 @@ def test_update_user(test_app, monkeypatch):
 
     # test update connected_user (dont alter username for other tests)
     test_update_data = {"username": "connected_user"}
-    response = test_app.put("/users/update-me", data=json.dumps(test_update_data))
+    response = test_app.put("/users/update-info", data=json.dumps(test_update_data))
     assert response.status_code == 200
     assert {k: v for k, v in response.json().items() if k != "created_at"} == {**test_update_data, "id": 99}
 
@@ -136,13 +136,13 @@ def test_update_user(test_app, monkeypatch):
         [0, {"username": "foo"}, 422],
     ],
 )
-def test_update_user_invalid(test_app, monkeypatch, user_id, payload, status_code):
+def test_update_user_info_invalid(test_app, monkeypatch, user_id, payload, status_code):
     async def mock_get(entry_id, table):
         return None
 
     monkeypatch.setattr(crud, "get", mock_get)
 
-    response = test_app.put(f"/users/{user_id}/", data=json.dumps(payload),)
+    response = test_app.put(f"/users/{user_id}/", data=json.dumps(payload))
     assert response.status_code == status_code, print(payload)
 
 


### PR DESCRIPTION
This PR adds the possibility of password update by:
- renaming the existing `/update-me` route to `/update-info` for coherence
- adding an admin and personal password update route. Both of them check if the entry exists, then hash the password and updates the entry in the table. For security reasons, instead of returning the input payload, I returned the user name to avoid exposing the password.
- adding corresponding unittests
- refactored schemas by adding a template class `_CreatedAt` and using multi-inheritance to avoid unneeded code duplication

I should bring your attention to route naming: I made the choice mentioned above but perhaps we should clarify the naming of all user routes since it's a complicated table.

Any feedback is welcome!